### PR TITLE
libstagefright: mtk: Use vendor extensions to check if we should fixu…

### DIFF
--- a/media/libstagefright/ACodec.cpp
+++ b/media/libstagefright/ACodec.cpp
@@ -4281,6 +4281,16 @@ status_t ACodec::getPortFormat(OMX_U32 portIndex, sp<AMessage> &notify) {
                         rect.nWidth = videoDef->nFrameWidth;
                         rect.nHeight = videoDef->nFrameHeight;
                     }
+#ifdef MTK_HARDWARE
+                    if (!strncmp(mComponentName.c_str(), "OMX.MTK.", 8) && mOMX->getConfig(
+                            mNode, (OMX_INDEXTYPE) 0x7f00001c /* OMX_IndexVendorMtkOmxVdecGetCropInfo */,
+                            &rect, sizeof(rect)) != OK) {
+                        rect.nLeft = 0;
+                        rect.nTop = 0;
+                        rect.nWidth = videoDef->nFrameWidth;
+                        rect.nHeight = videoDef->nFrameHeight;
+                    }
+#endif
 
                     if (rect.nLeft < 0 ||
                         rect.nTop < 0 ||


### PR DESCRIPTION
…p cropping

For mediatek video codecs, validate that the current cropped rectangle
is valid and use the full frame size otherwise. This fixes a bug where
format changes in the same native window would preserve the previous
cropping and cause most of the image to be off-screen.

Change-Id: If56ca11453f5d2e04a4138b2efe28203f30ba569
Ticket: PORRIDGE-440
